### PR TITLE
Fix link error in contribution.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ npm test
 npm run build
 npm run eject
 ```
-For detailed info on these commands and how to use them, check out [QP-Generator document](qp-generator/README.md).
+For detailed info on these commands and how to use them, check out [QP-Generator document](./README.md).
 
 * Open the project in your IDE/ text editor to use it.
 


### PR DESCRIPTION
### What is the change?
I have change the path. Previously It was `qp-generator/README.md` but this will not work.

### What does it fix/add?
By change the relative path.

### How was it tested?
By Clicking the text, now we are redirecting to `README.md`

## Submissions guide:
- [x] Have you followed the [Contribution guide](https://github.com/Team-Tomato/QP-Generator/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Team-Tomato/QP-Generator/pulls) for the same update/change?
- [x] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you lint your code locally prior to submission?
