### PR TITLE
Added text area and 2 buttons

### DIFF
--- a/qp-generator-frontend/src/Containers/generator.js
+++ b/qp-generator-frontend/src/Containers/generator.js
@@ -14,7 +14,7 @@ class Generator extends Component {
     this.state = {
       questions: [],
       section: [],
-      mathbar:-1
+      mathbar:-1,
     }
 
     this.handleChange = this.handleChange.bind(this)
@@ -23,6 +23,7 @@ class Generator extends Component {
     this.addSection = this.addSection.bind(this)
     this.handleBar = this.handleBar.bind(this)
     this.handleBarButton = this.handleBarButton.bind(this)
+    this.handlePhraseButton = this.handlePhraseButton.bind(this)
   }
 
   handleChange(e, index) {
@@ -47,6 +48,13 @@ class Generator extends Component {
     this.setState({mathbar:index})
     :
     this.setState({mathbar:-1})
+  }
+
+  // To handle the Re-phrase button functionality
+  handlePhraseButton(index) {
+    fetch('https://jsonplaceholder.typicode.com/todos/1')
+    .then(response => response.json())
+    .then(json => console.log(json))
   }
 
   handleDelete(index) {
@@ -101,8 +109,7 @@ class Generator extends Component {
         <IconButton aria-label="delete" onClick={this.handleAdd}> <AddIcon className="addbtn" /> </IconButton>
         <IconButton aria-label="delete" onClick={this.handleDelete}> <DeleteIcon className="addbtn" /> </IconButton>
         <Button onClick={()=>this.handleBarButton(0)}>MathBar</Button>
-        <Button onClick={()=>this.handleBarButton(0)}>Re-phrase</Button>
-        <Button onClick={()=>this.handleBarButton(0)}>Math</Button>
+        <Button onClick={()=>this.handlePhraseButton(0)}>Re-phrase</Button>
       </div>
     }
     else {

--- a/qp-generator-frontend/src/Containers/generator.js
+++ b/qp-generator-frontend/src/Containers/generator.js
@@ -90,9 +90,19 @@ class Generator extends Component {
           value=''
           onChange={e => this.handleChange(e, 0)}
         />
+        <TextField
+          id="marks"
+          name="marks"
+          label={`Marks`}
+          placeholder={`Marks`}
+          variant="outlined"
+          value=''
+        />
         <IconButton aria-label="delete" onClick={this.handleAdd}> <AddIcon className="addbtn" /> </IconButton>
         <IconButton aria-label="delete" onClick={this.handleDelete}> <DeleteIcon className="addbtn" /> </IconButton>
         <Button onClick={()=>this.handleBarButton(0)}>MathBar</Button>
+        <Button onClick={()=>this.handleBarButton(0)}>Re-phrase</Button>
+        <Button onClick={()=>this.handleBarButton(0)}>Math</Button>
       </div>
     }
     else {


### PR DESCRIPTION
### What is the change?
I have added a text area for marks and 2 buttons for Math and Re-phrase.

### What does it fix/add?
It is a new feature.

### How was it tested?
I ran the app on my local browser to check for elements.

## Submissions guide:
- [x] Have you followed the [Contribution guide](https://github.com/Team-Tomato/QP-Generator/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Team-Tomato/QP-Generator/pulls) for the same update/change?
- [ ] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [ ] Have you lint your code locally prior to submission?

### Screenshots (if appropriate):
![qp](https://user-images.githubusercontent.com/54858768/105027124-63fb0200-5a75-11eb-8fd6-e8fa2c920430.png)
